### PR TITLE
chore(commitlint): add commitlint and husky

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+test-results
+__tests__
+CODEOWNERS
+.travis.yml
+.eslintrc.json
+*.tgz
+.jest-cache
+.vscode
+commitlint.config.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
   - "10"
   - "12"
+before_install:
+  # Create a master branch for commitlint
+  # https://github.com/conventional-changelog/commitlint/issues/6
+  - git remote set-branches origin master && git fetch
 deploy:
   on:
     tags: true

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-case': [2, 'always', ['pascal-case', 'camel-case', 'kebab-case']],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,14 +6,19 @@
   "scripts": {
     "lint": "eslint ./ --ignore-path .gitignore --ext .js",
     "pretest": "npm run lint",
-    "test": "jest"
+    "test": "jest",
+    "test:git-history": "commitlint --from origin/master --to HEAD",
+    "posttest": "npm run test:git-history"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/americanexpress/babel-preset-amex.git"
   },
   "jest": {
-    "preset": "amex-jest-preset"
+    "preset": "amex-jest-preset",
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/commitlint.config.js"
+    ]
   },
   "keywords": [
     "babel",
@@ -30,9 +35,18 @@
     "@babel/preset-react": "^7.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0",
     "amex-jest-preset": "^5.0.0",
     "eslint": "^5.14.0",
     "eslint-config-amex": "^10.0.0",
+    "husky": "^3.1.0",
     "jest": "^24.1.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   }
 }


### PR DESCRIPTION
This adds commitlint along with husky. Furthermore, I added
```
before_install:
  # Create a master branch for commitlint
  # https://github.com/conventional-changelog/commitlint/issues/6
  - git remote set-branches origin master && git fetch
```

So travis does not break.