### PR TITLE
feat(plugins): add proposal optional chaining plugin

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -32,7 +32,7 @@ describe('babel-preset-amex', () => {
 
   it('includes an array of plugins', () => {
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toBe(3);
+    expect(preset().plugins.length).toBe(4);
     preset().plugins.forEach((plugin) => {
       // It should be either a function
       try {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const reactPreset = require('@babel/preset-react');
 const syntaxDynamicImport = require('@babel/plugin-syntax-dynamic-import').default;
 const proposalClassProperties = require('@babel/plugin-proposal-class-properties').default;
 const exportDefaultFrom = require('@babel/plugin-proposal-export-default-from').default;
+const proposalOptionalChaining = require('@babel/plugin-proposal-optional-chaining').default;
 
 const { browserlist, legacyBrowserList } = require('./browserlist');
 
@@ -46,5 +47,6 @@ module.exports = () => ({
     syntaxDynamicImport,
     proposalClassProperties,
     exportDefaultFrom,
+    proposalOptionalChaining,
   ],
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-proposal-export-default-from": "^7.5.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0"


### PR DESCRIPTION
Adds support for [optional chaining](https://tc39.es/proposal-optional-chaining/).

See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining