### PR TITLE
feat(index): add babel-plugin-transform-react-remove-prop-types

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -32,7 +32,7 @@ describe('babel-preset-amex', () => {
 
   it('includes an array of plugins', () => {
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toBe(4);
+    expect(preset().plugins.length).toBe(5);
     preset().plugins.forEach((plugin) => {
       // It should be either a function
       try {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const syntaxDynamicImport = require('@babel/plugin-syntax-dynamic-import').defau
 const proposalClassProperties = require('@babel/plugin-proposal-class-properties').default;
 const exportDefaultFrom = require('@babel/plugin-proposal-export-default-from').default;
 const proposalOptionalChaining = require('@babel/plugin-proposal-optional-chaining').default;
+const removePropTypes = require('babel-plugin-transform-react-remove-prop-types').default;
 
 const { browserlist, legacyBrowserList } = require('./browserlist');
 
@@ -48,5 +49,6 @@ module.exports = () => ({
     proposalClassProperties,
     exportDefaultFrom,
     proposalOptionalChaining,
+    removePropTypes,
   ],
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
-    "@babel/preset-react": "^7.0.0"
+    "@babel/preset-react": "^7.0.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",


### PR DESCRIPTION
If I have src/ExampleComponent.jsx which is comprised of:
```
import React from 'react';

const ExampleComponent = () => (
  <h1>Example</h1>
);

ExampleComponent.propTypes = {
  style: PropTypes.object.isRequired,
};
```

And this .babelrc:
```
{
  "presets": ["amex"]
}
```

`NODE_ENV=production npx babel src/ExampleComponent.jsx --out-file ExampleCompiled.js`
produces this ExampleCompiled.js file:
```
"use strict";

var _react = _interopRequireDefault(require("react"));

var _propTypes = _interopRequireDefault(require("prop-types"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var ExampleComponent = function ExampleComponent(style) {
  return _react.default.createElement("h1", {
    style: style
  }, "Example");
};

ExampleComponent.propTypes = {
  style: _propTypes.default.object.isRequired
};
```

After these 2 commands:
```
npm i -D PatNeedham/babel-preset-amex#feature/babel-plugin-transform-react-remove-prop-types
NODE_ENV=production npx babel src/ExampleComponent.jsx --out-file ExampleCompiled.js
```
the `ExampleComponent.propTypes` declaration was removed from the compiled file.