### PR TITLE
feat(preset-amex): make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,59 @@ npm install --save-dev babel-preset-amex
 }
 ```
 
+#### Options
+
+By default `babel-preset-amex` will transpile for the "last 2 versions" and "not dead" browsers.
+
+```json
+{
+  "presets": [[
+    "amex",
+    {
+      "serverOnly": true,
+      "modern": true,
+    }
+  ]]
+}
+```
+
+`serverOnly` - Will transpile only for node.
+`modern` - Will transpile for [common browsers](./browserlist.js) n-1.
+
+#### Customizing Babel Config
+
+Babel Preset Amex includes the following:
+
+Presets
+- [preset-env](https://babeljs.io/docs/en/babel-preset-env)
+- [preset-react](https://babeljs.io/docs/en/babel-preset-react)
+
+Plugins
+- [plugin-syntax-dynamic-import](https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import)
+- [plugin-proposal-class-properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties)
+- [plugin-proposal-export-default-from](https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from)
+- [plugin-proposal-optional-chaining](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining)
+- [babel-plugin-transform-react-remove-prop-types](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types)
+
+If you wish to re-configure any of those presets do not redefine them
+within you `.babelrc`. Instead you can configure them through the
+`amex` preset.
+
+```json
+{
+  "presets": [
+    [
+      "amex",
+      {
+        "preset-env": {},
+        "preset-react": {}
+      }
+    ]
+  ]
+};
+```
+
+
 ## 🏆 Contributing
 
 We welcome Your interest in the American Express Open Source Community on Github.

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -27,7 +27,7 @@ Object {
             "last 2 versions",
             "not dead",
           ],
-          "node": "12.16.1",
+          "node": "current",
         },
       },
     ],
@@ -69,7 +69,7 @@ Object {
             "last 2 iOS versions",
             "last 2 Safari versions",
           ],
-          "node": "12.16.1",
+          "node": "current",
         },
       },
     ],
@@ -111,7 +111,7 @@ Object {
             "last 2 iOS versions",
             "last 2 Safari versions",
           ],
-          "node": "12.16.1",
+          "node": "current",
         },
       },
     ],
@@ -145,7 +145,7 @@ Object {
       },
       Object {
         "targets": Object {
-          "node": "12.16.1",
+          "node": "current",
         },
       },
     ],
@@ -179,7 +179,7 @@ Object {
       },
       Object {
         "targets": Object {
-          "node": "12.16.1",
+          "node": "current",
         },
       },
     ],

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`babel-preset-amex allows options to be passed to plugins 1`] = `
+Object {
+  "plugins": Array [
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": [Function],
+        "getModulesPluginNames": [Function],
+        "getPolyfillPlugins": [Function],
+        "isPluginRequired": [Function],
+        "transformIncludesAndExcludes": [Function],
+      },
+      Object {
+        "exclude": Array [
+          "@babel/plugin-transform-regenerator",
+        ],
+        "targets": Object {
+          "browsers": Array [
+            "last 2 versions",
+            "not dead",
+          ],
+          "node": "12.16.1",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": [Function],
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
 exports[`babel-preset-amex returns modern preset for env and option 1`] = `
 Object {
   "plugins": Array [
@@ -19,7 +60,6 @@ Object {
         "transformIncludesAndExcludes": [Function],
       },
       Object {
-        "exclude": Array [],
         "targets": Object {
           "browsers": Array [
             "last 2 Chrome versions",
@@ -62,7 +102,6 @@ Object {
         "transformIncludesAndExcludes": [Function],
       },
       Object {
-        "exclude": Array [],
         "targets": Object {
           "browsers": Array [
             "last 2 Chrome versions",
@@ -105,9 +144,6 @@ Object {
         "transformIncludesAndExcludes": [Function],
       },
       Object {
-        "exclude": Array [
-          "@babel/plugin-transform-regenerator",
-        ],
         "targets": Object {
           "node": "12.16.1",
         },
@@ -142,9 +178,6 @@ Object {
         "transformIncludesAndExcludes": [Function],
       },
       Object {
-        "exclude": Array [
-          "@babel/plugin-transform-regenerator",
-        ],
         "targets": Object {
           "node": "12.16.1",
         },

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`babel-preset-amex returns modern preset for env and option 1`] = `
+Object {
+  "plugins": Array [
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": [Function],
+        "getModulesPluginNames": [Function],
+        "getPolyfillPlugins": [Function],
+        "isPluginRequired": [Function],
+        "transformIncludesAndExcludes": [Function],
+      },
+      Object {
+        "exclude": Array [],
+        "targets": Object {
+          "browsers": Array [
+            "last 2 Chrome versions",
+            "last 2 ChromeAndroid versions",
+            "last 2 Edge versions",
+            "last 2 Firefox versions",
+            "last 2 iOS versions",
+            "last 2 Safari versions",
+          ],
+          "node": "12.16.1",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": [Function],
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
+exports[`babel-preset-amex returns modern preset for env and option 2`] = `
+Object {
+  "plugins": Array [
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": [Function],
+        "getModulesPluginNames": [Function],
+        "getPolyfillPlugins": [Function],
+        "isPluginRequired": [Function],
+        "transformIncludesAndExcludes": [Function],
+      },
+      Object {
+        "exclude": Array [],
+        "targets": Object {
+          "browsers": Array [
+            "last 2 Chrome versions",
+            "last 2 ChromeAndroid versions",
+            "last 2 Edge versions",
+            "last 2 Firefox versions",
+            "last 2 iOS versions",
+            "last 2 Safari versions",
+          ],
+          "node": "12.16.1",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": [Function],
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
+exports[`babel-preset-amex returns server only config when given serverOnly option 1`] = `
+Object {
+  "plugins": Array [
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": [Function],
+        "getModulesPluginNames": [Function],
+        "getPolyfillPlugins": [Function],
+        "isPluginRequired": [Function],
+        "transformIncludesAndExcludes": [Function],
+      },
+      Object {
+        "exclude": Array [
+          "@babel/plugin-transform-regenerator",
+        ],
+        "targets": Object {
+          "node": "12.16.1",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": [Function],
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
+exports[`babel-preset-amex returns server only config when given serverOnly option 2`] = `
+Object {
+  "plugins": Array [
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+    [Function],
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": [Function],
+        "getModulesPluginNames": [Function],
+        "getPolyfillPlugins": [Function],
+        "isPluginRequired": [Function],
+        "transformIncludesAndExcludes": [Function],
+      },
+      Object {
+        "exclude": Array [
+          "@babel/plugin-transform-regenerator",
+        ],
+        "targets": Object {
+          "node": "12.16.1",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": [Function],
+      },
+      Object {},
+    ],
+  ],
+}
+`;

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -3,20 +3,16 @@
 exports[`babel-preset-amex allows options to be passed to plugins 1`] = `
 Object {
   "plugins": Array [
-    [Function],
-    [Function],
-    [Function],
-    [Function],
-    [Function],
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
       Object {
-        "default": [Function],
-        "getModulesPluginNames": [Function],
-        "getPolyfillPlugins": [Function],
-        "isPluginRequired": [Function],
-        "transformIncludesAndExcludes": [Function],
+        "default": "@babel/preset-env",
       },
       Object {
         "exclude": Array [
@@ -33,7 +29,7 @@ Object {
     ],
     Array [
       Object {
-        "default": [Function],
+        "default": "@babel/preset-react",
       },
       Object {},
     ],
@@ -44,20 +40,16 @@ Object {
 exports[`babel-preset-amex returns modern preset for env and option 1`] = `
 Object {
   "plugins": Array [
-    [Function],
-    [Function],
-    [Function],
-    [Function],
-    [Function],
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
       Object {
-        "default": [Function],
-        "getModulesPluginNames": [Function],
-        "getPolyfillPlugins": [Function],
-        "isPluginRequired": [Function],
-        "transformIncludesAndExcludes": [Function],
+        "default": "@babel/preset-env",
       },
       Object {
         "targets": Object {
@@ -75,7 +67,7 @@ Object {
     ],
     Array [
       Object {
-        "default": [Function],
+        "default": "@babel/preset-react",
       },
       Object {},
     ],
@@ -86,20 +78,16 @@ Object {
 exports[`babel-preset-amex returns modern preset for env and option 2`] = `
 Object {
   "plugins": Array [
-    [Function],
-    [Function],
-    [Function],
-    [Function],
-    [Function],
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
       Object {
-        "default": [Function],
-        "getModulesPluginNames": [Function],
-        "getPolyfillPlugins": [Function],
-        "isPluginRequired": [Function],
-        "transformIncludesAndExcludes": [Function],
+        "default": "@babel/preset-env",
       },
       Object {
         "targets": Object {
@@ -117,7 +105,7 @@ Object {
     ],
     Array [
       Object {
-        "default": [Function],
+        "default": "@babel/preset-react",
       },
       Object {},
     ],
@@ -128,20 +116,16 @@ Object {
 exports[`babel-preset-amex returns server only config when given serverOnly option 1`] = `
 Object {
   "plugins": Array [
-    [Function],
-    [Function],
-    [Function],
-    [Function],
-    [Function],
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
       Object {
-        "default": [Function],
-        "getModulesPluginNames": [Function],
-        "getPolyfillPlugins": [Function],
-        "isPluginRequired": [Function],
-        "transformIncludesAndExcludes": [Function],
+        "default": "@babel/preset-env",
       },
       Object {
         "targets": Object {
@@ -151,7 +135,7 @@ Object {
     ],
     Array [
       Object {
-        "default": [Function],
+        "default": "@babel/preset-react",
       },
       Object {},
     ],
@@ -162,20 +146,16 @@ Object {
 exports[`babel-preset-amex returns server only config when given serverOnly option 2`] = `
 Object {
   "plugins": Array [
-    [Function],
-    [Function],
-    [Function],
-    [Function],
-    [Function],
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
       Object {
-        "default": [Function],
-        "getModulesPluginNames": [Function],
-        "getPolyfillPlugins": [Function],
-        "isPluginRequired": [Function],
-        "transformIncludesAndExcludes": [Function],
+        "default": "@babel/preset-env",
       },
       Object {
         "targets": Object {
@@ -185,7 +165,7 @@ Object {
     ],
     Array [
       Object {
-        "default": [Function],
+        "default": "@babel/preset-react",
       },
       Object {},
     ],

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -20,10 +20,6 @@ describe('babel-preset-amex', () => {
     expect(preset()).toEqual(expect.any(Object));
   });
 
-  it('includes setting for modern browsers', () => {
-    expect(preset().env.modern).toEqual(expect.any(Object));
-  });
-
   it('includes an array of presets', () => {
     expect(preset().presets).toEqual(expect.any(Array));
     expect(preset().presets.length).toBe(2);
@@ -46,5 +42,21 @@ describe('babel-preset-amex', () => {
       expect(plugin[0]).toEqual(expect.any(Function));
       expect(plugin[1]).toEqual(expect.any(Object));
     });
+  });
+
+  it('returns modern preset for env and option', () => {
+    const presetModernOpt = preset({}, { modern: true });
+    const presetModernEnv = preset({ env: envName => envName === 'modern' });
+    expect(presetModernOpt).toMatchSnapshot();
+    expect(presetModernEnv).toMatchSnapshot();
+    expect(presetModernOpt).toEqual(presetModernEnv);
+  });
+
+  it('returns server only config when given serverOnly option', () => {
+    const presetServerOnlyOpt = preset({}, { serverOnly: true });
+    const presetServerEnv = preset({ env: envName => envName === 'server' });
+    expect(presetServerOnlyOpt).toMatchSnapshot();
+    expect(presetServerEnv).toMatchSnapshot();
+    expect(presetServerOnlyOpt).toEqual(presetServerEnv);
   });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -59,4 +59,8 @@ describe('babel-preset-amex', () => {
     expect(presetServerEnv).toMatchSnapshot();
     expect(presetServerOnlyOpt).toEqual(presetServerEnv);
   });
+
+  it('allows options to be passed to plugins', () => {
+    expect(preset({}, { 'preset-env': { exclude: ['@babel/plugin-transform-regenerator'] } })).toMatchSnapshot();
+  });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -14,6 +14,14 @@
 
 const preset = require('..');
 
+jest.mock('@babel/preset-env', () => ({ default: '@babel/preset-env' }));
+jest.mock('@babel/preset-react', () => ({ default: '@babel/preset-react' }));
+jest.mock('@babel/plugin-syntax-dynamic-import', () => ({ default: '@babel/plugin-syntax-dynamic-import' }));
+jest.mock('@babel/plugin-proposal-class-properties', () => ({ default: '@babel/plugin-proposal-class-properties' }));
+jest.mock('@babel/plugin-proposal-export-default-from', () => ({ default: '@babel/plugin-proposal-export-default-from' }));
+jest.mock('@babel/plugin-proposal-optional-chaining', () => ({ default: '@babel/plugin-proposal-optional-chaining' }));
+jest.mock('babel-plugin-transform-react-remove-prop-types', () => ({ default: 'babel-plugin-transform-react-remove-prop-types' }));
+
 describe('babel-preset-amex', () => {
   it('exports a function', () => {
     expect(preset).toEqual(expect.any(Function));
@@ -29,19 +37,6 @@ describe('babel-preset-amex', () => {
   it('includes an array of plugins', () => {
     expect(preset().plugins).toEqual(expect.any(Array));
     expect(preset().plugins.length).toBe(5);
-    preset().plugins.forEach((plugin) => {
-      // It should be either a function
-      try {
-        expect(plugin).toEqual(expect.any(Function));
-        return;
-      } catch (e) { /* do nothing */ }
-
-      // or an array containing a function and an object
-      expect(plugin).toEqual(expect.any(Array));
-      expect(plugin.length).toBe(2);
-      expect(plugin[0]).toEqual(expect.any(Function));
-      expect(plugin[1]).toEqual(expect.any(Object));
-    });
   });
 
   it('returns modern preset for env and option', () => {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = (api = {}, opts = {}) => {
   const isModern = opts.modern || (api.env && api.env('modern'));
 
   const targets = {
-    node: '12.16.1',
+    node: 'current',
   };
 
   if (!serverOnly) {

--- a/index.js
+++ b/index.js
@@ -34,14 +34,9 @@ module.exports = (api = {}, opts = {}) => {
     targets.browsers = isModern ? browserList : legacyBrowserList;
   }
 
-  const exclude = serverOnly ? ['@babel/plugin-transform-regenerator'] : [];
-
   const presetEnvOptions = Object.assign(
     {},
-    {
-      targets,
-      exclude,
-    },
+    { targets },
     opts['preset-env']
   );
 


### PR DESCRIPTION
Enable configuration of plugins and add `serverOnly` option to target node and exclude regenerator runtime. 