### PR TITLE
Use babel-plugin-transform-react-remove-prop-types plugin only for production mode

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -7,7 +7,6 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
-    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -44,7 +43,6 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
-    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -82,7 +80,6 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
-    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -120,7 +117,6 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
-    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -150,7 +146,6 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
-    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -7,6 +7,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -43,6 +44,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -80,6 +82,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -117,6 +120,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [
@@ -146,6 +150,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
     Array [

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -36,7 +36,7 @@ describe('babel-preset-amex', () => {
 
   it('includes an array of plugins', () => {
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toBe(5);
+    expect(preset().plugins.length).toBe(4);
   });
 
   it('returns modern preset for env and option', () => {
@@ -57,5 +57,15 @@ describe('babel-preset-amex', () => {
 
   it('allows options to be passed to plugins', () => {
     expect(preset({}, { 'preset-env': { exclude: ['@babel/plugin-transform-regenerator'] } })).toMatchSnapshot();
+  });
+
+  it('in production mode, includes an array of plugins', () => {
+    const originalEnv = process.env;
+    process.env = { NODE_ENV: 'production' };
+
+    expect(preset().plugins).toEqual(expect.any(Array));
+    expect(preset().plugins.length).toEqual(5);
+
+    process.env = originalEnv;
   });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -36,7 +36,7 @@ describe('babel-preset-amex', () => {
 
   it('includes an array of plugins', () => {
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toBe(4);
+    expect(preset().plugins.length).toBe(5);
   });
 
   it('returns modern preset for env and option', () => {
@@ -59,12 +59,12 @@ describe('babel-preset-amex', () => {
     expect(preset({}, { 'preset-env': { exclude: ['@babel/plugin-transform-regenerator'] } })).toMatchSnapshot();
   });
 
-  it('in production mode, includes an array of plugins', () => {
+  it('in development mode, includes an array of plugins', () => {
     const originalEnv = process.env;
-    process.env = { NODE_ENV: 'production' };
+    process.env = { NODE_ENV: 'development' };
 
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toEqual(5);
+    expect(preset().plugins.length).toEqual(4);
 
     process.env = originalEnv;
   });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,16 @@ const { browserList, legacyBrowserList } = require('./browserlist');
 module.exports = (api = {}, opts = {}) => {
   const serverOnly = opts.serverOnly || (api.env && api.env('server'));
   const isModern = opts.modern || (api.env && api.env('modern'));
+  const isProduction = process.env.NODE_ENV === 'production';
+  const plugins = [
+    syntaxDynamicImport,
+    proposalClassProperties,
+    exportDefaultFrom,
+    proposalOptionalChaining,
+  ];
+  if (isProduction) {
+    plugins.push(removePropTypes);
+  }
 
   const targets = {
     node: 'current',
@@ -53,12 +63,6 @@ module.exports = (api = {}, opts = {}) => {
         reactPresetOptions,
       ],
     ],
-    plugins: [
-      syntaxDynamicImport,
-      proposalClassProperties,
-      exportDefaultFrom,
-      proposalOptionalChaining,
-      removePropTypes,
-    ],
+    plugins,
   };
 };


### PR DESCRIPTION
Due to the fact babel-plugin-transform-react-remove-prop-types is used for both dev and prod builds, when you run an app locally no prop types warnings are thrown. The plugin should be used only for productions builds

## Description
babel-plugin-transform-react-remove-prop-types is included in the plugins list depending on the NODE_ENV

## Motivation and Context
This PR will fix prop types warnings, which are not shown now, in dev mode.

## How Has This Been Tested?
It was tested in One App application with several modules.
Initial state: development build of each module didn't contain propTypes for the module's components. 
With the proposed changes: development build of each module contains propTypes for the module's components, prod build doesn't contain propTypes for the module's components.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [x] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using babel-preset-amex?
The developers will see propTypes warnings in dev mode when they are using babel-preset-amex
