### PR TITLE
feat(plugins): add graphql import plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Plugins
 - [plugin-proposal-export-default-from](https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from)
 - [plugin-proposal-optional-chaining](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining)
 - [babel-plugin-transform-react-remove-prop-types](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types)
+- [babel-plugin-import-graphql](https://www.npmjs.com/package/babel-plugin-import-graphql)
 
 If you wish to re-configure any of those presets do not redefine them
 within you `.babelrc`. Instead you can configure them through the

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -7,6 +7,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    [Function],
     "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
@@ -44,6 +45,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    [Function],
     "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
@@ -82,6 +84,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    [Function],
     "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
@@ -120,6 +123,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    [Function],
     "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [
@@ -150,6 +154,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-optional-chaining",
+    [Function],
     "babel-plugin-transform-react-remove-prop-types",
   ],
   "presets": Array [

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -42,7 +42,7 @@ describe('babel-preset-amex', () => {
   it('includes an array of plugins in production', () => {
     process.env.NODE_ENV = 'production';
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toBe(5);
+    expect(preset().plugins.length).toBe(6);
   });
 
   it('returns modern preset for env and option', () => {
@@ -72,6 +72,6 @@ describe('babel-preset-amex', () => {
     process.env.NODE_ENV = 'development';
 
     expect(preset().plugins).toEqual(expect.any(Array));
-    expect(preset().plugins.length).toEqual(4);
+    expect(preset().plugins.length).toEqual(5);
   });
 });

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const proposalClassProperties = require('@babel/plugin-proposal-class-properties
 const exportDefaultFrom = require('@babel/plugin-proposal-export-default-from').default;
 const proposalOptionalChaining = require('@babel/plugin-proposal-optional-chaining').default;
 const removePropTypes = require('babel-plugin-transform-react-remove-prop-types').default;
+const importGraphQL = require('babel-plugin-import-graphql').default;
 
 const { browserList, legacyBrowserList } = require('./browserlist');
 
@@ -31,6 +32,7 @@ module.exports = (api = {}, opts = {}) => {
     proposalClassProperties,
     exportDefaultFrom,
     proposalOptionalChaining,
+    importGraphQL,
   ];
   if (isProduction) {
     plugins.push(removePropTypes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -15,6 +15,7 @@
         "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/preset-env": "^7.12.1",
         "@babel/preset-react": "^7.12.5",
+        "babel-plugin-import-graphql": "^2.8.1",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       },
       "devDependencies": {
@@ -4328,6 +4329,21 @@
         "object.assign": "^4.1.0"
       }
     },
+    "node_modules/babel-plugin-import-graphql": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import-graphql/-/babel-plugin-import-graphql-2.8.1.tgz",
+      "integrity": "sha512-j8Y0rWfMCd7Q63+hzCENrzbwYvQ9GfRbD3S50oHJ0SmEeRRVgLMxj+jXCBVLTFlmFLzY8UYVQQGx3FgrK3wajA==",
+      "dependencies": {
+        "graphql-tag": "^2.9.2"
+      },
+      "engines": {
+        "node": ">= 4.x"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.9.6",
+        "graphql-tag": "^2.1.0"
+      }
+    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -7802,6 +7818,34 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -24637,6 +24681,14 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-import-graphql": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import-graphql/-/babel-plugin-import-graphql-2.8.1.tgz",
+      "integrity": "sha512-j8Y0rWfMCd7Q63+hzCENrzbwYvQ9GfRbD3S50oHJ0SmEeRRVgLMxj+jXCBVLTFlmFLzY8UYVQQGx3FgrK3wajA==",
+      "requires": {
+        "graphql-tag": "^2.9.2"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -27482,6 +27534,27 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
+    },
+    "graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "peer": true
+    },
+    "graphql-tag": {
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.5",
+    "babel-plugin-import-graphql": "^2.8.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add babel-plugin-import-graphql. 

## Description
<!--- Describe your changes in detail -->
Adds a babel plugin that allows consumers of this preset to import graphql files as if they were JS files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As we migrate the front end to GraphQL this plugin will help to keep the code organized. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
npm linked to an existing module that is using apollo gql tags.
Created a new .gql file and moved the graphql queries from the gql tags into the standalone file.
Imported the file and verified that everything was working as intended.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using babel-preset-amex?
<!--- Please describe how your changes impacts developers using babel-preset-amex. -->
They will now be able to import gql and graphql files :).
