### PR TITLE
feat(moduleFormat): added new option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install --save-dev babel-preset-amex
 
 #### Options
 
-By default `babel-preset-amex` will transpile for the "last 2 versions" and "not dead" browsers.
+By default `babel-preset-amex` will transpile for the "last 2 versions," "not dead" browsers, and CommonJS module syntax.
 
 ```json
 {
@@ -46,6 +46,7 @@ By default `babel-preset-amex` will transpile for the "last 2 versions" and "not
     {
       "serverOnly": true,
       "modern": true,
+      "moduleFormat": "esm"
     }
   ]]
 }
@@ -53,6 +54,7 @@ By default `babel-preset-amex` will transpile for the "last 2 versions" and "not
 
 `serverOnly` - Will transpile only for node.
 `modern` - Will transpile for [common browsers](./browserlist.js) n-1.
+`moduleFormat` - Will transpile to ECMAScript module syntax. Any other string will transpile to CommonJS module syntax.
 
 #### Customizing Babel Config
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install --save-dev babel-preset-amex
 
 #### Options
 
-By default `babel-preset-amex` will transpile for the "last 2 versions," "not dead" browsers, and CommonJS module syntax.
+By default `babel-preset-amex` will transpile for the "last 2 versions", "not dead" browsers, and CommonJS module syntax.
 
 ```json
 {
@@ -54,7 +54,7 @@ By default `babel-preset-amex` will transpile for the "last 2 versions," "not de
 
 `serverOnly` - Will transpile only for node.
 `modern` - Will transpile for [common browsers](./browserlist.js) n-1.
-`moduleFormat` - Will transpile to ECMAScript module syntax. Any other string will transpile to CommonJS module syntax.
+`moduleFormat` - Will transpile to ECMAScript module syntax. Any string other than `"esm"` will transpile to CommonJS module syntax.
 
 #### Customizing Babel Config
 

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -37,6 +37,148 @@ Object {
 }
 `;
 
+exports[`babel-preset-amex moduleFormat allows an esm option 1`] = `
+Object {
+  "plugins": Array [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": "@babel/preset-env",
+      },
+      Object {
+        "modules": false,
+        "targets": Object {
+          "browsers": Array [
+            "last 2 versions",
+            "not dead",
+          ],
+          "node": "current",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": "@babel/preset-react",
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
+exports[`babel-preset-amex moduleFormat allows other options to be passed to preset-env while allowing esm option 1`] = `
+Object {
+  "plugins": Array [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": "@babel/preset-env",
+      },
+      Object {
+        "exclude": Array [
+          "@babel/plugin-transform-regenerator",
+        ],
+        "modules": false,
+        "targets": Object {
+          "browsers": Array [
+            "last 2 versions",
+            "not dead",
+          ],
+          "node": "current",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": "@babel/preset-react",
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
+exports[`babel-preset-amex moduleFormat does nothing when an unknown option is provided 1`] = `
+Object {
+  "plugins": Array [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": "@babel/preset-env",
+      },
+      Object {
+        "targets": Object {
+          "browsers": Array [
+            "last 2 versions",
+            "not dead",
+          ],
+          "node": "current",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": "@babel/preset-react",
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
+exports[`babel-preset-amex moduleFormat overrides an existing modules setting when esm option is used 1`] = `
+Object {
+  "plugins": Array [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-transform-react-remove-prop-types",
+  ],
+  "presets": Array [
+    Array [
+      Object {
+        "default": "@babel/preset-env",
+      },
+      Object {
+        "modules": false,
+        "targets": Object {
+          "browsers": Array [
+            "last 2 versions",
+            "not dead",
+          ],
+          "node": "current",
+        },
+      },
+    ],
+    Array [
+      Object {
+        "default": "@babel/preset-react",
+      },
+      Object {},
+    ],
+  ],
+}
+`;
+
 exports[`babel-preset-amex returns modern preset for env and option 1`] = `
 Object {
   "plugins": Array [

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -74,4 +74,26 @@ describe('babel-preset-amex', () => {
     expect(preset().plugins).toEqual(expect.any(Array));
     expect(preset().plugins.length).toEqual(4);
   });
+
+  describe('moduleFormat', () => {
+    it('allows an esm option', () => {
+      process.env.NODE_ENV = 'production';
+      expect(preset({}, { moduleFormat: 'esm' })).toMatchSnapshot();
+    });
+
+    it('overrides an existing modules setting when esm option is used', () => {
+      process.env.NODE_ENV = 'production';
+      expect(preset({}, { 'preset-env': { modules: true }, moduleFormat: 'esm' })).toMatchSnapshot();
+    });
+
+    it('allows other options to be passed to preset-env while allowing esm option', () => {
+      process.env.NODE_ENV = 'production';
+      expect(preset({}, { 'preset-env': { exclude: ['@babel/plugin-transform-regenerator'] }, moduleFormat: 'esm' })).toMatchSnapshot();
+    });
+
+    it('does nothing when an unknown option is provided', () => {
+      process.env.NODE_ENV = 'production';
+      expect(preset({}, { moduleFormat: 'cjs' })).toMatchSnapshot();
+    });
+  });
 });

--- a/index.js
+++ b/index.js
@@ -47,10 +47,8 @@ module.exports = (api = {}, opts = {}) => {
   const presetEnvOptions = Object.assign(
     {},
     { targets },
-    Object.assign({},
-      opts['preset-env'],
-      opts.moduleFormat === 'esm' && { modules: false }
-    )
+    opts['preset-env'],
+    opts.moduleFormat === 'esm' && { modules: false }
   );
 
   const reactPresetOptions = Object.assign({}, opts['react-preset']);

--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ module.exports = (api = {}, opts = {}) => {
   const presetEnvOptions = Object.assign(
     {},
     { targets },
-    opts['preset-env']
+    Object.assign({},
+      opts['preset-env'],
+      opts.moduleFormat === 'esm' && { modules: false }
+    )
   );
 
   const reactPresetOptions = Object.assign({}, opts['react-preset']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds an option `moduleFormat` to `preset-env`. It takes a string and the value should be `esm` in order for the feature to be enabled. With this option, it allows a developer to choose the output of their package: CommonJS or ECMAScript module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change enables dependency developers to have their package tree-shaken by any bundler that supports tree-shaking. Tree-shaking is a technique that removes dead code, or code not used by a module that is consuming a dependency. This reduces the size of a package allowing for faster delivery of JavaScript files across the network.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on a system with these characteristics:
* npm@6.14.13
* node@12.22.3
* macOS@11.15.1

This change has been tested in a simple npm dependency configured with the following `.babelrc` file:
```json
{
  "env": {
    "development": {
      "presets": ["amex"]
    },
    "production": {
      "presets": [["amex", { "moduleFormat": "esm", "modern": true } ]]
    }
  }
}
```
And then in the `build` script inside `package.json` of such dependency, the following was added:
```json
{
  "build": "cross-env BABEL_ENV=production babel src --out-dir build/ejs --copy-files && cross-env BABEL_ENV=development babel src --out-dir build/cjs --copy-files"
}
```
Note: `cross-env` is an [open-source tool](https://www.npmjs.com/package/cross-env) that enables environment variables to work across any development environment.

As a result of running these scripts, it was observed that files in `build/ejs` had ECMAScript modules and files in `build/cjs` had CommonJS modules.

Further, extensive unit tests were written to handle various cases where additional `preset-env` options were provided to ensure that those options were not overwritten.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [x] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using babel-preset-amex?
<!--- Please describe how your changes impacts developers using babel-preset-amex. -->
Developers will be able to enable their dependencies to be tree-shaken by a bundler that supports tree-shaking. This allows developers to write packages without worrying bloating the size of consumers with code that won't be used.
